### PR TITLE
Reduce frequency of log when component is disabled

### DIFF
--- a/modules/core/src/de/diedavids/cuba/dblocalization/core/DbMessagesImpl.java
+++ b/modules/core/src/de/diedavids/cuba/dblocalization/core/DbMessagesImpl.java
@@ -1,7 +1,6 @@
 package de.diedavids.cuba.dblocalization.core;
 
 import com.haulmont.cuba.core.global.DataManager;
-import com.haulmont.cuba.core.sys.AbstractMessages;
 import com.haulmont.cuba.core.sys.AppContext;
 import com.haulmont.cuba.core.sys.MessagesImpl;
 import com.haulmont.cuba.security.app.Authentication;
@@ -28,6 +27,7 @@ public class DbMessagesImpl extends MessagesImpl {
     @Inject
     DbMessagesConfig dbMessagesConfig;
 
+    private long nextNotification = 0;
 
     @Override
     protected String searchOnePack(String pack, String key, Locale locale, Locale truncatedLocale, Set<String> passedPacks) {
@@ -49,22 +49,25 @@ public class DbMessagesImpl extends MessagesImpl {
     }
 
     private Optional<Localization> searchKeyInDatabase(String key, Locale locale) {
-
         if (dbMessagesConfig.getEnabled()) {
             log.debug("DB based message lookup active. DB Lookup will be executed");
             authentication.begin();
-
             Optional<Localization> translatedMessage = dataManager.load(Localization.class)
                     .query("select e from ddcdl_Localization e where e.key = :key and e.locale = :locale")
                     .parameter("key", key)
                     .parameter("locale", locale)
                     .optional();
-
             authentication.end();
             return translatedMessage;
-        }
-        else {
-            log.info("DB based message lookup inactive. Fallback to default behavior.");
+        } else {
+            if (nextNotification < System.currentTimeMillis()) {
+                log.info("DB based message lookup inactive. Fallback to default behavior.");
+                if (dbMessagesConfig.getLogWarningDelay() < 1000) {
+                    nextNotification = Long.MAX_VALUE;
+                } else {
+                    nextNotification = System.currentTimeMillis() + dbMessagesConfig.getLogWarningDelay();
+                }
+            }
             return Optional.empty();
         }
     }

--- a/modules/core/src/de/diedavids/cuba/dblocalization/core/DbMessagesImpl.java
+++ b/modules/core/src/de/diedavids/cuba/dblocalization/core/DbMessagesImpl.java
@@ -38,7 +38,9 @@ public class DbMessagesImpl extends MessagesImpl {
             if (translatedMessage.isPresent()) {
                 Localization localization = translatedMessage.get();
                 String value = localization.getValue();
-                log.debug(String.format("DB based message found for key '%s': '%s' (%s)", key, value, localization.getId()));
+                if (log.isDebugEnabled()) {
+                    log.debug(String.format("DB based message found for key '%s': '%s' (%s)", key, value, localization.getId()));
+                }
                 return value;
             } else {
                 return super.searchOnePack(pack, key, locale, truncatedLocale, passedPacks);

--- a/modules/core/src/de/diedavids/cuba/dblocalization/service/LocalizationServiceBean.java
+++ b/modules/core/src/de/diedavids/cuba/dblocalization/service/LocalizationServiceBean.java
@@ -1,11 +1,9 @@
 package de.diedavids.cuba.dblocalization.service;
 
-import com.haulmont.cuba.core.EntityManager;
 import com.haulmont.cuba.core.Persistence;
 import com.haulmont.cuba.core.entity.FileDescriptor;
 import com.haulmont.cuba.core.global.*;
 import de.diedavids.cuba.dblocalization.entity.Localization;
-import org.apache.commons.io.IOUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Service;
@@ -15,8 +13,9 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.nio.charset.StandardCharsets;
-import java.util.*;
-import java.util.stream.Collectors;
+import java.util.Enumeration;
+import java.util.Locale;
+import java.util.Properties;
 
 @Service(LocalizationService.NAME)
 public class LocalizationServiceBean implements LocalizationService {
@@ -40,19 +39,14 @@ public class LocalizationServiceBean implements LocalizationService {
 
     @Override
     public void initialImport(FileDescriptor fileDescriptor, Locale locale) {
-
-
         CommitContext commitContext = new CommitContext();
 
-        try {
-            InputStream stream = fileLoader.openStream(fileDescriptor);
-
-            try (InputStreamReader reader = new InputStreamReader(stream, StandardCharsets.UTF_8)) {
+        try (InputStream stream = fileLoader.openStream(fileDescriptor);
+             InputStreamReader reader = new InputStreamReader(stream, StandardCharsets.UTF_8);){
                 Properties properties = new Properties();
                 properties.load(reader);
 
                 Enumeration<?> propertyNames = properties.propertyNames();
-
 
                 while (propertyNames.hasMoreElements()) {
                     String key = (String) propertyNames.nextElement();
@@ -65,13 +59,8 @@ public class LocalizationServiceBean implements LocalizationService {
                             )
                     );
                 }
-
-
                 dataManager.commit(commitContext);
 
-            } finally {
-                IOUtils.closeQuietly(stream);
-            }
         } catch (FileStorageException | IOException e) {
             e.printStackTrace();
         }

--- a/modules/global/src/de/diedavids/cuba/dblocalization/config/DbMessagesConfig.java
+++ b/modules/global/src/de/diedavids/cuba/dblocalization/config/DbMessagesConfig.java
@@ -5,6 +5,7 @@ import com.haulmont.cuba.core.config.Property;
 import com.haulmont.cuba.core.config.Source;
 import com.haulmont.cuba.core.config.SourceType;
 import com.haulmont.cuba.core.config.defaults.DefaultBoolean;
+import com.haulmont.cuba.core.config.defaults.DefaultLong;
 
 @Source(type = SourceType.APP)
 public interface DbMessagesConfig extends Config {
@@ -16,4 +17,8 @@ public interface DbMessagesConfig extends Config {
     @Property("dblocalization.enabled")
     @DefaultBoolean(false)
     boolean getEnabled();
+
+    @Property("dblocalization.logWarningDelay")
+    @DefaultLong(15 * 60 * 1000L)
+    long getLogWarningDelay();
 }

--- a/modules/web/src/de/diedavids/cuba/dblocalization/web/DbMessagesClientImpl.java
+++ b/modules/web/src/de/diedavids/cuba/dblocalization/web/DbMessagesClientImpl.java
@@ -1,8 +1,6 @@
 package de.diedavids.cuba.dblocalization.web;
 
 import com.haulmont.cuba.client.sys.MessagesClientImpl;
-import com.haulmont.cuba.core.global.UserSessionSource;
-import com.haulmont.cuba.core.sys.AbstractMessages;
 import de.diedavids.cuba.dblocalization.config.DbMessagesConfig;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -17,6 +15,7 @@ public class DbMessagesClientImpl extends MessagesClientImpl {
     private static final Logger log = LoggerFactory.getLogger(DbMessagesClientImpl.class);
     @Inject
     protected DbMessagesConfig dbMessagesConfig;
+    private long nextNotification = 0;
 
     @Override
     protected String searchOnePack(String pack, String key, Locale locale, Locale truncatedLocale, Set<String> passedPacks) {
@@ -29,7 +28,6 @@ public class DbMessagesClientImpl extends MessagesClientImpl {
 
         // if db-based message lookup is enabled, lookup in the DB first
         if (dbMessagesConfig.getEnabled()) {
-
             log.debug("DB based message lookup active. Remote Lookup will be executed");
             // switch to search remotely first so that DB based entries are taken first
             if (locale.equals(truncatedLocale)) {
@@ -47,7 +45,14 @@ public class DbMessagesClientImpl extends MessagesClientImpl {
 
         // else default behavior
         else {
-            log.info("DB based message lookup inactive. Fallback to default behavior.");
+            if (nextNotification < System.currentTimeMillis()) {
+                log.info("DB based message lookup inactive. Fallback to default behavior.");
+                if (dbMessagesConfig.getLogWarningDelay() < 1000) {
+                    nextNotification = Long.MAX_VALUE;
+                } else {
+                    nextNotification = System.currentTimeMillis() + dbMessagesConfig.getLogWarningDelay();
+                }
+            }
 
             msg = searchFiles(pack, key, locale, truncatedLocale, passedPacks);
             if (msg == null) {


### PR DESCRIPTION
If the component is not enabled, the error is logged too often.

I propose a patch to reduce the frequency of the message to once every 15 minutes (can be changd if you find it not suitable via configuration)